### PR TITLE
Use version-sync crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ ndarray = "0.10"
 num-traits = "0.1"
 rand = "0.3"
 rand_derive = "0.3"
+
+[dev-dependencies]
+version-sync = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc(html_root_url = "https://docs.rs/smawk/0.1.0")]
+
 #[macro_use(s)]
 extern crate ndarray;
 extern crate num_traits;

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -1,0 +1,12 @@
+#[macro_use]
+extern crate version_sync;
+
+#[test]
+fn test_readme_deps() {
+    assert_markdown_deps_updated!("README.md");
+}
+
+#[test]
+fn test_html_root_url() {
+    assert_html_root_url_updated!("src/lib.rs");
+}


### PR DESCRIPTION
This crate makes it easy to keep version numbers in sync with the crate version.