### PR TITLE
Add function variants for column minima

### DIFF
--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -5,18 +5,17 @@ extern crate rand;
 extern crate smawk;
 extern crate test;
 
-use ndarray::Array2;
 use rand::XorShiftRng;
 use test::Bencher;
 
 macro_rules! repeat {
-    ([ $( ($func:ident, $size:expr) $(,)* )* ], $body:expr) => {
+    ([ $( ($func:ident, $size:expr) $(,)* )* ], $row_func:path) => {
         $(
             #[bench]
             fn $func(b: &mut Bencher) {
                 let mut rng = XorShiftRng::new_unseeded();
                 let matrix = smawk::random_monge_matrix($size, $size, &mut rng);
-                b.iter(|| $body(&matrix));
+                b.iter(|| $row_func(&matrix));
             }
         )*
     };
@@ -27,7 +26,7 @@ repeat!([(brute_force_025, 25),
          (brute_force_100, 100),
          (brute_force_200, 200),
          (brute_force_400, 400)],
-        |matrix: &Array2<i32>| smawk::brute_force_row_minima(&matrix));
+        smawk::brute_force_row_minima);
 
 repeat!([(recursive_0025, 25),
          (recursive_0050, 50),
@@ -35,7 +34,7 @@ repeat!([(recursive_0025, 25),
          (recursive_0200, 200),
          (recursive_0400, 400),
          (recursive_0800, 800)],
-        |matrix: &Array2<i32>| smawk::recursive_row_minima(&matrix));
+        smawk::recursive_row_minima);
 
 repeat!([(smawk_025, 25),
          (smawk_050, 50),
@@ -43,4 +42,4 @@ repeat!([(smawk_025, 25),
          (smawk_200, 200),
          (smawk_400, 400),
          (smawk_800, 800)],
-        |matrix: &Array2<i32>| smawk::smawk_row_minima(&matrix));
+        smawk::smawk_row_minima);

--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -9,37 +9,46 @@ use rand::XorShiftRng;
 use test::Bencher;
 
 macro_rules! repeat {
-    ([ $( ($func:ident, $size:expr) $(,)* )* ], $row_func:path) => {
+    ([ $( ($row_bench:ident, $column_bench:ident, $size:expr) $(,)* )* ],
+     $row_func:path, $column_func:path) => {
         $(
             #[bench]
-            fn $func(b: &mut Bencher) {
+            fn $row_bench(b: &mut Bencher) {
                 let mut rng = XorShiftRng::new_unseeded();
                 let matrix = smawk::random_monge_matrix($size, $size, &mut rng);
                 b.iter(|| $row_func(&matrix));
+            }
+
+            #[bench]
+            fn $column_bench(b: &mut Bencher) {
+                let mut rng = XorShiftRng::new_unseeded();
+                let matrix = smawk::random_monge_matrix($size, $size, &mut rng).reversed_axes();
+                b.iter(|| $column_func(&matrix));
             }
         )*
     };
 }
 
-repeat!([(brute_force_025, 25),
-         (brute_force_050, 50),
-         (brute_force_100, 100),
-         (brute_force_200, 200),
-         (brute_force_400, 400)],
-        smawk::brute_force_row_minima);
+repeat!([(row_brute_force_025, column_brute_force_025, 25),
+         (row_brute_force_050, column_brute_force_050, 50),
+         (row_brute_force_100, column_brute_force_100, 100),
+         (row_brute_force_200, column_brute_force_200, 200),
+         (row_brute_force_400, column_brute_force_400, 400)],
+        smawk::brute_force_row_minima,
+        smawk::brute_force_column_minima);
 
-repeat!([(recursive_0025, 25),
-         (recursive_0050, 50),
-         (recursive_0100, 100),
-         (recursive_0200, 200),
-         (recursive_0400, 400),
-         (recursive_0800, 800)],
-        smawk::recursive_row_minima);
+repeat!([(row_recursive_025, column_recursive_025, 25),
+         (row_recursive_050, column_recursive_050, 50),
+         (row_recursive_100, column_recursive_100, 100),
+         (row_recursive_200, column_recursive_200, 200),
+         (row_recursive_400, column_recursive_400, 400)],
+        smawk::recursive_row_minima,
+        smawk::recursive_column_minima);
 
-repeat!([(smawk_025, 25),
-         (smawk_050, 50),
-         (smawk_100, 100),
-         (smawk_200, 200),
-         (smawk_400, 400),
-         (smawk_800, 800)],
-        smawk::smawk_row_minima);
+repeat!([(row_smawk_025, column_smawk_025, 25),
+         (row_smawk_050, column_smawk_050, 50),
+         (row_smawk_100, column_smawk_100, 100),
+         (row_smawk_200, column_smawk_200, 200),
+         (row_smawk_400, column_smawk_400, 400)],
+        smawk::smawk_row_minima,
+        smawk::smawk_column_minima);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,9 +529,9 @@ mod tests {
         assert_eq!(smawk_column_minima(&matrix.reversed_axes()), minima);
     }
 
-    /// Check that the brute_force_row_minima, recursive_row_minima,
-    /// and smawk_row_minima functions give identical results on a
-    /// large number of randomly generated Monge matrices.
+    /// Check that the brute force, recursive, and SMAWK functions
+    /// give identical results on a large number of randomly generated
+    /// Monge matrices.
     #[test]
     fn implementations_agree() {
         let sizes = vec![1, 2, 3, 4, 5, 10, 15, 20, 30];
@@ -540,9 +540,24 @@ mod tests {
             for m in sizes.clone().iter() {
                 for n in sizes.clone().iter() {
                     let matrix = random_monge_matrix(*m, *n, &mut rng);
+
+                    // Compute and test row minima.
                     let brute_force = brute_force_row_minima(&matrix);
                     let recursive = recursive_row_minima(&matrix);
                     let smawk = smawk_row_minima(&matrix);
+                    assert_eq!(brute_force,
+                               recursive,
+                               "recursive and brute force differs on:\n{:?}",
+                               matrix);
+                    assert_eq!(brute_force,
+                               smawk,
+                               "SMAWK and brute force differs on:\n{:?}",
+                               matrix);
+
+                    // Do the same for the column minima.
+                    let brute_force = brute_force_column_minima(&matrix);
+                    let recursive = recursive_column_minima(&matrix);
+                    let smawk = smawk_column_minima(&matrix);
                     assert_eq!(brute_force,
                                recursive,
                                "recursive and brute force differs on:\n{:?}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,26 @@ pub fn smawk_row_minima(matrix: &Array2<i32>) -> Vec<usize> {
     minima
 }
 
+/// Compute column-minima using the SMAWK algorithm.
+///
+/// Running time on an *m* ✕ *n* matrix: O(*m* + *n*).
+///
+/// # Panics
+///
+/// It is an error to call this on a matrix with zero rows.
+pub fn smawk_column_minima(matrix: &Array2<i32>) -> Vec<usize> {
+    // Benchmarking shows that SMAWK performs roughly the same on row-
+    // and column-major matrices.
+    let mut minima = vec![0; matrix.cols()];
+    smawk_inner(&matrix.t(),
+                &(0..matrix.cols()).collect::<Vec<_>>(),
+                &(0..matrix.rows()).collect::<Vec<_>>(),
+                &mut minima);
+    minima
+}
+
+/// Compute row minima in the given area of the matrix. The `minima`
+/// slice is updated inplace.
 fn smawk_inner(matrix: &ArrayView2<i32>, rows: &[usize], cols: &[usize], mut minima: &mut [usize]) {
     if rows.is_empty() {
         return;
@@ -454,6 +474,7 @@ mod tests {
         let matrix = arr2(&[[2]]);
         let minima = vec![0];
         assert_eq!(smawk_row_minima(&matrix), minima);
+        assert_eq!(smawk_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]
@@ -461,6 +482,7 @@ mod tests {
         let matrix = arr2(&[[3], [2]]);
         let minima = vec![0, 0];
         assert_eq!(smawk_row_minima(&matrix), minima);
+        assert_eq!(smawk_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]
@@ -468,6 +490,7 @@ mod tests {
         let matrix = arr2(&[[2, 1]]);
         let minima = vec![1];
         assert_eq!(smawk_row_minima(&matrix), minima);
+        assert_eq!(smawk_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]
@@ -475,6 +498,7 @@ mod tests {
         let matrix = arr2(&[[3, 2], [2, 1]]);
         let minima = vec![1, 1];
         assert_eq!(smawk_row_minima(&matrix), minima);
+        assert_eq!(smawk_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]
@@ -482,6 +506,7 @@ mod tests {
         let matrix = arr2(&[[3, 4, 4], [3, 4, 4], [2, 3, 3]]);
         let minima = vec![0, 0, 0];
         assert_eq!(smawk_row_minima(&matrix), minima);
+        assert_eq!(smawk_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]
@@ -489,6 +514,7 @@ mod tests {
         let matrix = arr2(&[[4, 5, 5, 5], [2, 3, 3, 3], [2, 3, 3, 3], [2, 2, 2, 2]]);
         let minima = vec![0, 0, 0, 0];
         assert_eq!(smawk_row_minima(&matrix), minima);
+        assert_eq!(smawk_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]
@@ -500,6 +526,7 @@ mod tests {
                             [4, 3, 2, 1, 1]]);
         let minima = vec![1, 1, 1, 1, 3];
         assert_eq!(smawk_row_minima(&matrix), minima);
+        assert_eq!(smawk_column_minima(&matrix.reversed_axes()), minima);
     }
 
     /// Check that the brute_force_row_minima, recursive_row_minima,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,31 +51,28 @@ pub fn brute_force_column_minima(matrix: &Array2<i32>) -> Vec<usize> {
 ///
 /// It is an error to call this on a matrix with zero columns.
 pub fn recursive_row_minima(matrix: &Array2<i32>) -> Vec<usize> {
-    fn inner(matrix: ArrayView2<i32>, x_offset: usize, minima: &mut [usize]) {
-        if matrix.is_empty() {
-            return;
-        }
+    let mut minima = vec![0; matrix.rows()];
+    recursive_inner(matrix.view(), 0, &mut minima);
+    minima
+}
 
-        let mid_row = matrix.rows() / 2;
-        let min_idx = lane_minimum(matrix.row(mid_row));
-        minima[mid_row] = x_offset + min_idx;
-
-        if mid_row == 0 {
-            return; // Matrix has a single row, so we're done.
-        }
-
-        let top_left = matrix.slice(s![..mid_row as isize, ..(min_idx + 1) as isize]);
-        inner(top_left, x_offset, &mut minima[..mid_row]);
-
-        let bot_right = matrix.slice(s![(mid_row + 1) as isize.., min_idx as isize..]);
-        inner(bot_right, x_offset + min_idx, &mut minima[mid_row + 1..]);
-
+fn recursive_inner(matrix: ArrayView2<i32>, x_offset: usize, minima: &mut [usize]) {
+    if matrix.is_empty() {
+        return;
     }
 
-    let mut minima = vec![0; matrix.rows()];
-    inner(matrix.view(), 0, &mut minima);
+    let mid_row = matrix.rows() / 2;
+    let min_idx = lane_minimum(matrix.row(mid_row));
+    minima[mid_row] = x_offset + min_idx;
 
-    minima
+    if mid_row == 0 {
+        return; // Matrix has a single row, so we're done.
+    }
+
+    let top_left = matrix.slice(s![..mid_row as isize, ..(min_idx + 1) as isize]);
+    let bot_right = matrix.slice(s![(mid_row + 1) as isize.., min_idx as isize..]);
+    recursive_inner(top_left, x_offset, &mut minima[..mid_row]);
+    recursive_inner(bot_right, x_offset + min_idx, &mut minima[mid_row + 1..]);
 }
 
 /// Compute row-minima using the SMAWK algorithm.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,16 +11,16 @@ use ndarray::{Array2, ArrayView1, ArrayView2};
 use num_traits::{NumOps, PrimInt};
 use rand::{Rand, Rng};
 
-/// Compute row minimum by brute force.
+/// Compute lane minimum by brute force.
 ///
-/// This does a simple scan through the row.
+/// This does a simple scan through the lane (row or column).
 #[inline]
-fn row_minimum(row: ArrayView1<i32>) -> usize {
-    row.iter()
+fn lane_minimum(lane: ArrayView1<i32>) -> usize {
+    lane.iter()
         .enumerate()
         .min_by_key(|&(idx, elem)| (elem, idx))
         .map(|(idx, _)| idx)
-        .expect("empty row in matrix")
+        .expect("empty lane in matrix")
 }
 
 /// Compute row minima by brute force.
@@ -31,7 +31,7 @@ fn row_minimum(row: ArrayView1<i32>) -> usize {
 ///
 /// It is an error to call this on a matrix with zero columns.
 pub fn brute_force_row_minima(matrix: &Array2<i32>) -> Vec<usize> {
-    matrix.genrows().into_iter().map(row_minimum).collect()
+    matrix.genrows().into_iter().map(lane_minimum).collect()
 }
 
 /// Compute row minima in O(*m* + *n* log *m*) time.
@@ -46,7 +46,7 @@ pub fn recursive_row_minima(matrix: &Array2<i32>) -> Vec<usize> {
         }
 
         let mid_row = matrix.rows() / 2;
-        let min_idx = row_minimum(matrix.row(mid_row));
+        let min_idx = lane_minimum(matrix.row(mid_row));
         minima[mid_row] = x_offset + min_idx;
 
         if mid_row == 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,17 @@ pub fn brute_force_row_minima(matrix: &Array2<i32>) -> Vec<usize> {
     matrix.genrows().into_iter().map(lane_minimum).collect()
 }
 
+/// Compute column minima by brute force.
+///
+/// Running time on an *m* ✕ *n* matrix: O(*mn*).
+///
+/// # Panics
+///
+/// It is an error to call this on a matrix with zero rows.
+pub fn brute_force_column_minima(matrix: &Array2<i32>) -> Vec<usize> {
+    matrix.gencolumns().into_iter().map(lane_minimum).collect()
+}
+
 /// Compute row minima in O(*m* + *n* log *m*) time.
 ///
 /// # Panics
@@ -274,6 +285,7 @@ mod tests {
         let matrix = arr2(&[[2]]);
         let minima = vec![0];
         assert_eq!(brute_force_row_minima(&matrix), minima);
+        assert_eq!(brute_force_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]
@@ -281,6 +293,7 @@ mod tests {
         let matrix = arr2(&[[3], [2]]);
         let minima = vec![0, 0];
         assert_eq!(brute_force_row_minima(&matrix), minima);
+        assert_eq!(brute_force_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]
@@ -288,6 +301,7 @@ mod tests {
         let matrix = arr2(&[[2, 1]]);
         let minima = vec![1];
         assert_eq!(brute_force_row_minima(&matrix), minima);
+        assert_eq!(brute_force_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]
@@ -295,6 +309,7 @@ mod tests {
         let matrix = arr2(&[[3, 2], [2, 1]]);
         let minima = vec![1, 1];
         assert_eq!(brute_force_row_minima(&matrix), minima);
+        assert_eq!(brute_force_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]
@@ -302,6 +317,7 @@ mod tests {
         let matrix = arr2(&[[3, 4, 4], [3, 4, 4], [2, 3, 3]]);
         let minima = vec![0, 0, 0];
         assert_eq!(brute_force_row_minima(&matrix), minima);
+        assert_eq!(brute_force_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]
@@ -309,6 +325,7 @@ mod tests {
         let matrix = arr2(&[[4, 5, 5, 5], [2, 3, 3, 3], [2, 3, 3, 3], [2, 2, 2, 2]]);
         let minima = vec![0, 0, 0, 0];
         assert_eq!(brute_force_row_minima(&matrix), minima);
+        assert_eq!(brute_force_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]
@@ -320,6 +337,7 @@ mod tests {
                             [4, 3, 2, 1, 1]]);
         let minima = vec![1, 1, 1, 1, 3];
         assert_eq!(brute_force_row_minima(&matrix), minima);
+        assert_eq!(brute_force_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,17 @@ pub fn recursive_row_minima(matrix: &Array2<i32>) -> Vec<usize> {
     minima
 }
 
+/// Compute column minima in O(*n* + *m* log *n*) time.
+///
+/// # Panics
+///
+/// It is an error to call this on a matrix with zero rows.
+pub fn recursive_column_minima(matrix: &Array2<i32>) -> Vec<usize> {
+    let mut minima = vec![0; matrix.cols()];
+    recursive_inner(matrix.view(), Axis(1), 0, &mut minima);
+    minima
+}
+
 /// Compute the minima along the given axis (`Axis(0)` for row minima
 /// and `Axis(1)` for column minima).
 fn recursive_inner(matrix: ArrayView2<i32>, axis: Axis, offset: usize, minima: &mut [usize]) {
@@ -363,6 +374,7 @@ mod tests {
         let matrix = arr2(&[[2]]);
         let minima = vec![0];
         assert_eq!(recursive_row_minima(&matrix), minima);
+        assert_eq!(recursive_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]
@@ -370,6 +382,7 @@ mod tests {
         let matrix = arr2(&[[3], [2]]);
         let minima = vec![0, 0];
         assert_eq!(recursive_row_minima(&matrix), minima);
+        assert_eq!(recursive_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]
@@ -377,6 +390,7 @@ mod tests {
         let matrix = arr2(&[[2, 1]]);
         let minima = vec![1];
         assert_eq!(recursive_row_minima(&matrix), minima);
+        assert_eq!(recursive_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]
@@ -384,6 +398,7 @@ mod tests {
         let matrix = arr2(&[[3, 2], [2, 1]]);
         let minima = vec![1, 1];
         assert_eq!(recursive_row_minima(&matrix), minima);
+        assert_eq!(recursive_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]
@@ -391,6 +406,7 @@ mod tests {
         let matrix = arr2(&[[3, 4, 4], [3, 4, 4], [2, 3, 3]]);
         let minima = vec![0, 0, 0];
         assert_eq!(recursive_row_minima(&matrix), minima);
+        assert_eq!(recursive_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]
@@ -398,6 +414,7 @@ mod tests {
         let matrix = arr2(&[[4, 5, 5, 5], [2, 3, 3, 3], [2, 3, 3, 3], [2, 2, 2, 2]]);
         let minima = vec![0, 0, 0, 0];
         assert_eq!(recursive_row_minima(&matrix), minima);
+        assert_eq!(recursive_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]
@@ -409,6 +426,7 @@ mod tests {
                             [4, 3, 2, 1, 1]]);
         let minima = vec![1, 1, 1, 1, 3];
         assert_eq!(recursive_row_minima(&matrix), minima);
+        assert_eq!(recursive_column_minima(&matrix.reversed_axes()), minima);
     }
 
     #[test]


### PR DESCRIPTION
This PR adds new functions that compute column minima instead of row minima:

* `brute_force_column_minima`, 
* `recursive_column_minima`, and
* `smaws_column_minima`.