### PR TITLE
rustfmt: use default formatting

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,7 +1,0 @@
-reorder_imports_in_group = true
-reorder_imported_names = true
-array_layout = "Visual"
-control_style = "Legacy"
-fn_args_layout = "Visual"
-fn_call_style = "Visual"
-generics_indent = "Visual"

--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -29,26 +29,38 @@ macro_rules! repeat {
     };
 }
 
-repeat!([(row_brute_force_025, column_brute_force_025, 25),
-         (row_brute_force_050, column_brute_force_050, 50),
-         (row_brute_force_100, column_brute_force_100, 100),
-         (row_brute_force_200, column_brute_force_200, 200),
-         (row_brute_force_400, column_brute_force_400, 400)],
-        smawk::brute_force_row_minima,
-        smawk::brute_force_column_minima);
+repeat!(
+    [
+        (row_brute_force_025, column_brute_force_025, 25),
+        (row_brute_force_050, column_brute_force_050, 50),
+        (row_brute_force_100, column_brute_force_100, 100),
+        (row_brute_force_200, column_brute_force_200, 200),
+        (row_brute_force_400, column_brute_force_400, 400)
+    ],
+    smawk::brute_force_row_minima,
+    smawk::brute_force_column_minima
+);
 
-repeat!([(row_recursive_025, column_recursive_025, 25),
-         (row_recursive_050, column_recursive_050, 50),
-         (row_recursive_100, column_recursive_100, 100),
-         (row_recursive_200, column_recursive_200, 200),
-         (row_recursive_400, column_recursive_400, 400)],
-        smawk::recursive_row_minima,
-        smawk::recursive_column_minima);
+repeat!(
+    [
+        (row_recursive_025, column_recursive_025, 25),
+        (row_recursive_050, column_recursive_050, 50),
+        (row_recursive_100, column_recursive_100, 100),
+        (row_recursive_200, column_recursive_200, 200),
+        (row_recursive_400, column_recursive_400, 400)
+    ],
+    smawk::recursive_row_minima,
+    smawk::recursive_column_minima
+);
 
-repeat!([(row_smawk_025, column_smawk_025, 25),
-         (row_smawk_050, column_smawk_050, 50),
-         (row_smawk_100, column_smawk_100, 100),
-         (row_smawk_200, column_smawk_200, 200),
-         (row_smawk_400, column_smawk_400, 400)],
-        smawk::smawk_row_minima,
-        smawk::smawk_column_minima);
+repeat!(
+    [
+        (row_smawk_025, column_smawk_025, 25),
+        (row_smawk_050, column_smawk_050, 50),
+        (row_smawk_100, column_smawk_100, 100),
+        (row_smawk_200, column_smawk_200, 200),
+        (row_smawk_400, column_smawk_400, 400)
+    ],
+    smawk::smawk_row_minima,
+    smawk::smawk_column_minima
+);


### PR DESCRIPTION
With the recent changes to rustfmt, most of the directives in our
config file stopped working. So it seems like it'll be easier to just
use the defaults going forward.