### PR TITLE
Online SMAWK algorithm for finding column minima

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,7 @@ fn smawk_inner<T: Ord>(
 /// inequality holds:
 ///
 /// ```text
-/// M[i, j] + M[i', j'] <= M[i, j'] + M[i, j']  for all i < i', j < j'
+/// M[i, j] + M[i', j'] <= M[i, j'] + M[i', j]  for all i < i', j < j'
 /// ```
 ///
 /// The inequality says that the sum of the main diagonal is less than

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,6 +350,7 @@ pub fn online_column_minima<M: Fn(&[(usize, i32)], usize, usize) -> i32>(
     // we don't want to borrow the result vector.
     macro_rules! m {
         ($i:expr, $j:expr) => {{
+            assert!($i < $j, "(i, j) not above diagonal: ({}, {})", $i, $j);
             assert!(
                 $i < size && $j < size,
                 "index out of bounds: ({}, {}), matrix size: {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,68 @@
+//! This crate implements various functions that help speed up dynamic
+//! programming, most importantly the SMAWK algorithm for finding row
+//! or column minima in a totally monotone matrix with *m* rows and
+//! *n* columns in time O(*m* + *n*). This is much better than the
+//! brute force solution which would take O(*mn*). When *m* and *n*
+//! are of the same order, this turns a quadratic function into a
+//! linear function.
+//!
+//! Some of the functions in this crate only work on matrices that are
+//! *totally monotone*, which we will define below.
+//!
+//! # Monotone Matrices
+//!
+//! We start with a helper definition. Given an *m* ✕ *n* matrix `M`,
+//! we say that `M` is *monotone* when the minimum value of row `i` is
+//! found to the left of the minimum value in row `i'` where `i < i'`.
+//!
+//! More formally, if we let `rm(i)` denote the column index of the
+//! left-most minimum value in row `i`, then we have
+//!
+//! ```text
+//! rm(0) ≤ rm(1) ≤ ... ≤ rm(m - 1)
+//! ```
+//!
+//! This means that as you go down the rows from top to bottom, the
+//! row-minima proceed from left to right.
+//!
+//! The algorithms in this crate deal with finding such row- and
+//! column-minima.
+//!
+//! # Totally Monotone Matrices
+//!
+//! We say that a matrix `M` is *totally monotone* when every
+//! sub-matrix is monotone. A sub-matrix is formed by the intersection
+//! of any two rows `i < i'` and any two columns `j < j'`.
+//!
+//! This is often expressed as via this equivalent condition:
+//!
+//! ```text
+//! M[i, j] > M[i, j']  =>  M[i', j] > M[i', j']
+//! ```
+//!
+//! for all `i < i'` and `j < j'`.
+//!
+//! # Monge Property for Matrices
+//!
+//! A matrix `M` is said to fulfill the *Monge property* if
+//!
+//! ```text
+//! M[i, j] + M[i', j'] ≤ M[i, j'] + M[i', j]
+//! ```
+//!
+//! for all `i < i'` and `j < j'`. This says that given any rectangle
+//! in the matrix, the sum of the top-left and bottom-right corners is
+//! less than or equal to the sum of the bottom-left and upper-right
+//! corners.
+//!
+//! All Monge matrices are totally monotone, so it is enough to
+//! establish that the Monge property holds in order to use a matrix
+//! with the functions in this crate. If your program is dealing with
+//! unknown inputs, it can use [`is_monge`] to verify that a matrix is
+//! a Monge matrix.
+//!
+//! [`is_monge`]: fn.is_monge.html
+
 #![doc(html_root_url = "https://docs.rs/smawk/0.1.0")]
 
 #[macro_use(s)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,7 +353,7 @@ pub fn online_column_minima<M: Fn(&[(usize, i32)], usize, usize) -> i32>(
             assert!($i < $j, "(i, j) not above diagonal: ({}, {})", $i, $j);
             assert!(
                 $i < size && $j < size,
-                "index out of bounds: ({}, {}), matrix size: {}",
+                "(i, j) out of bounds: ({}, {}), size: {}",
                 $i,
                 $j,
                 size

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,17 @@ fn recursive_inner<T: Ord, F: Fn() -> Direction>(
     );
 }
 
-/// Compute row-minima using the SMAWK algorithm.
+/// Compute row minima in O(*m* + *n*) time.
+///
+/// This implements the SMAWK algorithm for finding row minima in a
+/// totally monotone matrix.
+///
+/// The SMAWK algorithm is from Agarwal, Klawe, Moran, Shor, and
+/// Wilbur, *Geometric applications of a matrix searching algorithm*,
+/// Algorithmica 2, pp. 195-208 (1987) and the code here is a
+/// translation [David Eppstein's Python code][pads].
+///
+/// [pads]: https://github.com/jfinkels/PADS/blob/master/pads/smawk.py
 ///
 /// Running time on an *m* ✕ *n* matrix: O(*m* + *n*).
 ///
@@ -149,7 +159,17 @@ pub fn smawk_row_minima<T: Ord>(matrix: &Array2<T>) -> Vec<usize> {
     minima
 }
 
-/// Compute column-minima using the SMAWK algorithm.
+/// Compute column minima in O(*m* + *n*) time.
+///
+/// This implements the SMAWK algorithm for finding column minima in a
+/// totally monotone matrix.
+///
+/// The SMAWK algorithm is from Agarwal, Klawe, Moran, Shor, and
+/// Wilbur, *Geometric applications of a matrix searching algorithm*,
+/// Algorithmica 2, pp. 195-208 (1987) and the code here is a
+/// translation [David Eppstein's Python code][pads].
+///
+/// [pads]: https://github.com/jfinkels/PADS/blob/master/pads/smawk.py
 ///
 /// Running time on an *m* ✕ *n* matrix: O(*m* + *n*).
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,10 +225,7 @@ fn smawk_inner<T: Ord>(
     smawk_inner(&matrix, &odd_rows, cols, &mut minima);
 
     let mut c = 0;
-    for (r, &row) in rows.iter().enumerate() {
-        if r % 2 == 1 {
-            continue;
-        }
+    for (r, &row) in rows.iter().enumerate().filter(|(r, _)| r % 2 == 0) {
         let mut col = cols[c];
         let last_col = if r == rows.len() - 1 {
             cols[cols.len() - 1]

--- a/tests/complexity.rs
+++ b/tests/complexity.rs
@@ -1,0 +1,84 @@
+extern crate ndarray;
+extern crate rand;
+extern crate smawk;
+
+use ndarray::{Array1, Array2, Axis};
+use rand::XorShiftRng;
+use smawk::{online_column_minima, random_monge_matrix};
+use std::borrow::Borrow;
+
+#[derive(Debug)]
+struct LinRegression {
+    alpha: f64,
+    beta: f64,
+    r_squared: f64,
+}
+
+/// Square an expression. Works equally well for floats and matrices.
+macro_rules! squared {
+    ($x:expr) => {
+        $x * $x
+    };
+}
+
+/// Compute the mean of a 1-dimensional array.
+fn mean<T, A>(a: A) -> T
+where
+    T: ndarray::LinalgScalar,
+    A: Borrow<Array1<T>>,
+{
+    a.borrow().mean_axis(Axis(0))[[]]
+}
+
+/// Compute a simple linear regression from the list of values.
+///
+/// See <https://en.wikipedia.org/wiki/Simple_linear_regression>.
+fn linear_regression(values: &[(usize, i32)]) -> LinRegression {
+    let xs = Array1::from_iter(values.iter().map(|&(x, _)| x as f64));
+    let ys = Array1::from_iter(values.iter().map(|&(_, y)| y as f64));
+
+    let xs_mean = mean(&xs);
+    let ys_mean = mean(&ys);
+    let xs_ys_mean = mean(&xs * &ys);
+
+    let cov_xs_ys = ((&xs - xs_mean) * (&ys - ys_mean)).scalar_sum();
+    let var_xs = squared!(&xs - xs_mean).scalar_sum();
+
+    let beta = cov_xs_ys / var_xs;
+    let alpha = ys_mean - beta * xs_mean;
+    let r_squared = squared!(xs_ys_mean - xs_mean * ys_mean)
+        / ((mean(&xs * &xs) - squared!(xs_mean)) * (mean(&ys * &ys) - squared!(ys_mean)));
+
+    LinRegression {
+        alpha: alpha,
+        beta: beta,
+        r_squared: r_squared,
+    }
+}
+
+/// Check that the number of matrix accesses in `online_column_minima`
+/// grows as O(*n*) for *n* ✕ *n* matrix.
+#[test]
+fn online_linear_complexity() {
+    let mut rng = XorShiftRng::new_unseeded();
+    let mut data = vec![];
+
+    for &size in &[1, 2, 3, 4, 5, 10, 15, 20, 30, 40, 50, 60, 70, 80, 90, 100] {
+        let mut matrix: Array2<i32> = random_monge_matrix(size, size, &mut rng);
+        let count = std::cell::RefCell::new(0);
+        online_column_minima(0, size, |_, i, j| {
+            *count.borrow_mut() += 1;
+            matrix[[i, j]]
+        });
+        data.push((size, count.into_inner()));
+    }
+
+    let lin_reg = linear_regression(&data);
+    assert!(
+        lin_reg.r_squared > 0.95,
+        "r² = {:.4} is lower than expected for a linear fit\nData points: {:?}\n{:?}",
+        lin_reg.r_squared,
+        data,
+        lin_reg
+    );
+}


### PR DESCRIPTION
This PR adds the `online_column_minima` function from [PADS][1]. This function finds column minima above the main diagonal and it finds them in an *online* fashion, which means that the matrix accessor function can use previously computed column minima to compute future matrix entries. Like the regular offline SMAWK algorithm, the `online_column_minima` function runs in time O(*n*) for an *n* by *n* input matrix.

[1]: https://github.com/jfinkels/PADS/blob/master/pads/smawk.py