### PR TITLE
Simplify CI scripts by making them less verbose

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,21 +3,13 @@ environment:
   - TOOLCHAIN: stable
   - TOOLCHAIN: nightly
 
-matrix:
-  allow_failures:
-    - TOOLCHAIN: nightly
-
 install:
   - ps: Start-FileDownload 'https://static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe'
-  - rustup-init.exe -y --default-toolchain %TOOLCHAIN%
+  - rustup-init.exe -y --profile minimal --default-toolchain %TOOLCHAIN%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
 
 build_script:
-  - cargo build --verbose
+  - cargo build
 
 test_script:
-  - cargo test --verbose
-
-cache:
-  - '%USERPROFILE%\.cargo'
-  - target
+  - cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ rust:
   - stable
   - nightly
 
-cache: cargo
+install:
+  - cargo build
 
-matrix:
-  allow_failures:
-    - rust: nightly
+script:
+  - cargo test


### PR DESCRIPTION
This also drops the caching. Reading and writing the caches take a significant amount of time and I've seen diminishing returns in my other projects.