### PR TITLE
Drop strict Rust 2018 compatibility by not testing with Rust 1.31.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: rust
 
 rust:
-  - 1.31.0 # Rust 2018
   - stable
   - nightly
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![](https://img.shields.io/crates/v/smawk.svg)][crates-io]
 [![](https://docs.rs/smawk/badge.svg)][api-docs]
-[![](https://img.shields.io/badge/rustc-1.31.0-blue.svg)][rust-2018]
 [![](https://travis-ci.org/mgeisler/smawk.svg)][travis-ci]
 [![](https://ci.appveyor.com/api/projects/status/github/mgeisler/smawk?branch=master&svg=true)][appveyor]
 [![](https://codecov.io/gh/mgeisler/smawk/branch/master/graph/badge.svg)][codecov]
@@ -57,8 +56,8 @@ This is a changelog describing the most important changes per release.
 
 ### Unreleased
 
-Switched to [Rust 2018][rust-2018], which means that the minimum
-supported Rust version is 1.31.0.
+Switched to the [Rust 2018][rust-2018] edition. We test against the
+latest stable and nightly version of Rust.
 
 ### Version 0.1.0 — August 7th, 2018
 

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -4,13 +4,6 @@ fn test_readme_deps() {
 }
 
 #[test]
-fn test_minimum_rustc_version() {
-    let version = r"1\.31\.0";
-    version_sync::assert_contains_regex!(".travis.yml", &format!(r"^  - {}", version));
-    version_sync::assert_contains_regex!("README.md", &format!("badge/rustc-{}", version));
-}
-
-#[test]
 fn test_html_root_url() {
     version_sync::assert_html_root_url_updated!("src/lib.rs");
 }


### PR DESCRIPTION
As dependencies update, it's infeasible to keep the code compatible with Rust 1.31.0.