### PR TITLE
Drop unnecessary Windows tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,14 +9,11 @@ jobs:
   build:
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
         rust:
           - stable
           - nightly
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This is a library that does numeric computations, so the operating
system should not matter.