### PR TITLE
Fix heading level in auto-generated README

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -81,11 +81,11 @@ jobs:
 
             var readme = fs.readFileSync('README.md', 'utf8')
             const today = new Date().toISOString().split('T')[0]
-            const heading = `## Version ${new_version} (${today})\n`
-            if (readme.match('## Unreleased')) {
-              readme = readme.replace('## Unreleased', `${heading}\n${changelog}`)
+            const heading = `### Version ${new_version} (${today})\n`
+            if (readme.match('### Unreleased')) {
+              readme = readme.replace('### Unreleased', `${heading}\n${changelog}`)
             } else {
-              readme = readme.replace('# Changelog', `# Changelog\n\n${heading}\n${changelog}`)
+              readme = readme.replace('## Changelog', `## Changelog\n\n${heading}\n${changelog}`)
             }
             fs.writeFileSync('README.md', readme)
 

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           NAME=$(cargo metadata -q --no-deps | jq -r '.packages[0].name')
           VERSION=$(cargo metadata -q --no-deps | jq -r '.packages[0].version')
-          CHANGELOG=$(awk '/^## Version/ {i++}; i==1 {print}; i>1 {exit}' README.md \
+          CHANGELOG=$(awk '/^### Version/ {i++}; i==1 {print}; i>1 {exit}' README.md \
             | python3 -c 'import sys, json; print(json.dumps(sys.stdin.read()))')
           echo "::set-output name=name::$NAME"
           echo "::set-output name=version::$VERSION"


### PR DESCRIPTION
The per-release headings in the auto-generated changelog used the wrong level. The code worked by accident since there was an existing `### Unreleased` heading, but it would have been broken next time.