### PR TITLE
Cleanup Rust 2015-style `extern crate` statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,11 @@ Add this to your `Cargo.toml`:
 [dependencies]
 smawk = "0.2"
 ```
-and this to your crate root:
-```rust
-extern crate smawk;
-```
 
 You can now efficiently find row and column minima. Here is an example
 where we find the column minima:
 
 ```rust
-extern crate ndarray;
-extern crate smawk;
-
 use ndarray::arr2;
 use smawk::smawk_column_minima;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,6 @@
 //! done efficiently with `smawk_column_minima`:
 //!
 //! ```
-//! extern crate ndarray;
-//! extern crate smawk;
-//!
 //! use ndarray::arr2;
 //! use smawk::smawk_column_minima;
 //!


### PR DESCRIPTION
We only support Rust 2018 so these statements are no longer useful.