### PR TITLE
Make the dependency on the ndarray crate optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ appveyor = { repository = "mgeisler/smawk" }
 codecov = { repository = "mgeisler/smawk" }
 
 [dependencies]
-ndarray = "0.13"
+ndarray = { version = "0.13", optional = true }
 num-traits = "0.2"
 rand = "0.7"
 

--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "ndarray")]
 #![feature(test)]
 
 extern crate test;

--- a/src/brute_force.rs
+++ b/src/brute_force.rs
@@ -1,4 +1,10 @@
 //! Brute-force algorithm for finding column minima.
+//!
+//! The functions here are mostly meant to be used for testing
+//! correctness of the SMAWK implementation.
+//!
+//! **Note: this module is only available if you enable the `ndarray`
+//! Cargo feature.**
 
 use ndarray::{Array2, ArrayView1};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,8 +90,11 @@
 
 #![doc(html_root_url = "https://docs.rs/smawk/0.2.0")]
 
+#[cfg(feature = "ndarray")]
 pub mod brute_force;
+#[cfg(feature = "ndarray")]
 pub mod monge;
+#[cfg(feature = "ndarray")]
 pub mod recursive;
 
 /// Minimal matrix trait for two-dimensional arrays.
@@ -101,6 +104,9 @@ pub mod recursive;
 /// elements. Modeled after
 /// [`ndarray::Array2`](https://docs.rs/ndarray/latest/ndarray/type.Array2.html)
 /// from the [ndarray crate ](https://crates.io/crates/ndarray).
+///
+/// Enable the `ndarray` Cargo feature if you want to use it with
+/// `ndarray::Array2`.
 pub trait Matrix<T: Copy> {
     /// Return the number of rows.
     fn nrows(&self) -> usize;
@@ -129,6 +135,10 @@ impl<T: Copy> Matrix<T> for Vec<Vec<T>> {
 }
 
 /// Adapting `ndarray::Array2` to the `Matrix` trait.
+///
+/// **Note: this implementation is only available if you enable the
+/// `ndarray` Cargo feature.**
+#[cfg(feature = "ndarray")]
 impl<T: Copy> Matrix<T> for ndarray::Array2<T> {
     #[inline]
     fn nrows(&self) -> usize {

--- a/src/monge.rs
+++ b/src/monge.rs
@@ -1,4 +1,10 @@
 //! Functions for generating and checking Monge arrays.
+//!
+//! The functions here are mostly meant to be used for testing
+//! correctness of the SMAWK implementation.
+//!
+//! **Note: this module is only available if you enable the `ndarray`
+//! Cargo feature.**
 
 use ndarray::{s, Array2};
 use num_traits::{PrimInt, WrappingAdd};

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -1,4 +1,10 @@
 //! Recursive algorithm for finding column minima.
+//!
+//! The functions here are mostly meant to be used for testing
+//! correctness of the SMAWK implementation.
+//!
+//! **Note: this module is only available if you enable the `ndarray`
+//! Cargo feature.**
 
 use ndarray::{s, Array2, ArrayView2, Axis};
 

--- a/tests/agreement.rs
+++ b/tests/agreement.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "ndarray")]
+
 use ndarray::{s, Array2};
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;

--- a/tests/complexity.rs
+++ b/tests/complexity.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "ndarray")]
+
 use ndarray::{Array1, Array2};
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;


### PR DESCRIPTION
The SMAWK algorithms work fine without the ndarray and this slims down the crate by making the largest dependency optional.