### PR TITLE
Remove mandatory dependencies on rand and num-traits crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ codecov = { repository = "mgeisler/smawk" }
 
 [dependencies]
 ndarray = { version = "0.13", optional = true }
-num-traits = "0.2"
-rand = "0.7"
 
 [dev-dependencies]
 version-sync = "0.9"
+num-traits = "0.2"
+rand = "0.7"
 rand_chacha = "0.2"

--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -8,6 +8,10 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use test::Bencher;
 
+#[path = "../tests/random_monge/mod.rs"]
+mod random_monge;
+use random_monge::random_monge_matrix;
+
 macro_rules! repeat {
     ([ $( ($row_bench:ident, $column_bench:ident, $size:expr) $(,)* )* ],
      $row_func:path, $column_func:path) => {
@@ -15,14 +19,14 @@ macro_rules! repeat {
             #[bench]
             fn $row_bench(b: &mut Bencher) {
                 let mut rng = ChaCha20Rng::seed_from_u64(0);
-                let matrix: Array2<i32> = smawk::monge::random_monge_matrix($size, $size, &mut rng);
+                let matrix: Array2<i32> = random_monge_matrix($size, $size, &mut rng);
                 b.iter(|| $row_func(&matrix));
             }
 
             #[bench]
             fn $column_bench(b: &mut Bencher) {
                 let mut rng = ChaCha20Rng::seed_from_u64(0);
-                let matrix: Array2<i32> = smawk::monge::random_monge_matrix($size, $size, &mut rng).reversed_axes();
+                let matrix: Array2<i32> = random_monge_matrix($size, $size, &mut rng).reversed_axes();
                 b.iter(|| $column_func(&matrix));
             }
         )*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,6 @@
 
 #[cfg(feature = "ndarray")]
 pub mod brute_force;
-#[cfg(feature = "ndarray")]
 pub mod monge;
 #[cfg(feature = "ndarray")]
 pub mod recursive;

--- a/tests/agreement.rs
+++ b/tests/agreement.rs
@@ -3,8 +3,11 @@
 use ndarray::{s, Array2};
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
-use smawk::{brute_force, monge, recursive};
+use smawk::{brute_force, recursive};
 use smawk::{online_column_minima, smawk_column_minima, smawk_row_minima};
+
+mod random_monge;
+use random_monge::random_monge_matrix;
 
 /// Check that the brute force, recursive, and SMAWK functions
 /// give identical results on a large number of randomly generated
@@ -16,7 +19,7 @@ fn column_minima_agree() {
     for _ in 0..4 {
         for m in sizes.clone().iter() {
             for n in sizes.clone().iter() {
-                let matrix: Array2<i32> = monge::random_monge_matrix(*m, *n, &mut rng);
+                let matrix: Array2<i32> = random_monge_matrix(*m, *n, &mut rng);
 
                 // Compute and test row minima.
                 let brute_force = brute_force::row_minima(&matrix);
@@ -63,7 +66,7 @@ fn online_agree() {
         for &size in &sizes {
             // Random totally monotone square matrix of the
             // desired size.
-            let mut matrix: Array2<i32> = monge::random_monge_matrix(size, size, &mut rng);
+            let mut matrix: Array2<i32> = random_monge_matrix(size, size, &mut rng);
 
             // Adjust matrix so the column minima are above the
             // diagonal. The brute_force::column_minima will still

--- a/tests/complexity.rs
+++ b/tests/complexity.rs
@@ -3,8 +3,10 @@
 use ndarray::{Array1, Array2};
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
-use smawk::monge::random_monge_matrix;
 use smawk::online_column_minima;
+
+mod random_monge;
+use random_monge::random_monge_matrix;
 
 #[derive(Debug)]
 struct LinRegression {

--- a/tests/monge.rs
+++ b/tests/monge.rs
@@ -1,0 +1,83 @@
+#![cfg(feature = "ndarray")]
+
+use ndarray::{arr2, Array, Array2};
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use smawk::monge::is_monge;
+
+mod random_monge;
+use random_monge::{random_monge_matrix, MongePrim};
+
+#[test]
+fn random_monge() {
+    let mut rng = ChaCha20Rng::seed_from_u64(0);
+    let matrix: Array2<u8> = random_monge_matrix(5, 5, &mut rng);
+
+    assert!(is_monge(&matrix));
+    assert_eq!(
+        matrix,
+        arr2(&[
+            [2, 3, 4, 4, 5],
+            [5, 5, 6, 6, 7],
+            [3, 3, 4, 4, 5],
+            [5, 2, 3, 3, 4],
+            [5, 2, 3, 3, 4]
+        ])
+    );
+}
+
+#[test]
+fn monge_constant_rows() {
+    let mut rng = ChaCha20Rng::seed_from_u64(0);
+    let matrix: Array2<u8> = MongePrim::ConstantRows.to_matrix(5, 4, &mut rng);
+    assert!(is_monge(&matrix));
+    for row in matrix.genrows() {
+        let elem = row[0];
+        assert_eq!(row, Array::from_elem(matrix.ncols(), elem));
+    }
+}
+
+#[test]
+fn monge_constant_cols() {
+    let mut rng = ChaCha20Rng::seed_from_u64(0);
+    let matrix: Array2<u8> = MongePrim::ConstantCols.to_matrix(5, 4, &mut rng);
+    assert!(is_monge(&matrix));
+    for column in matrix.gencolumns() {
+        let elem = column[0];
+        assert_eq!(column, Array::from_elem(matrix.nrows(), elem));
+    }
+}
+
+#[test]
+fn monge_upper_right_ones() {
+    let mut rng = ChaCha20Rng::seed_from_u64(1);
+    let matrix: Array2<u8> = MongePrim::UpperRightOnes.to_matrix(5, 4, &mut rng);
+    assert!(is_monge(&matrix));
+    assert_eq!(
+        matrix,
+        arr2(&[
+            [0, 0, 1, 1],
+            [0, 0, 1, 1],
+            [0, 0, 1, 1],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0]
+        ])
+    );
+}
+
+#[test]
+fn monge_lower_left_ones() {
+    let mut rng = ChaCha20Rng::seed_from_u64(1);
+    let matrix: Array2<u8> = MongePrim::LowerLeftOnes.to_matrix(5, 4, &mut rng);
+    assert!(is_monge(&matrix));
+    assert_eq!(
+        matrix,
+        arr2(&[
+            [0, 0, 0, 0],
+            [0, 0, 0, 0],
+            [1, 1, 0, 0],
+            [1, 1, 0, 0],
+            [1, 1, 0, 0]
+        ])
+    );
+}

--- a/tests/random_monge/mod.rs
+++ b/tests/random_monge/mod.rs
@@ -1,0 +1,83 @@
+//! Test functionality for generating random Monge matrices.
+
+// The code is put here so we can reuse it in different integration
+// tests, without Cargo finding it when `cargo test` is run. See the
+// section on "Submodules in Integration Tests" in
+// https://doc.rust-lang.org/book/ch11-03-test-organization.html
+
+use ndarray::{s, Array2};
+use num_traits::PrimInt;
+use rand::distributions::{Distribution, Standard};
+use rand::Rng;
+
+/// A Monge matrix can be decomposed into one of these primitive
+/// building blocks.
+#[derive(Copy, Clone)]
+pub enum MongePrim {
+    ConstantRows,
+    ConstantCols,
+    UpperRightOnes,
+    LowerLeftOnes,
+}
+
+impl MongePrim {
+    /// Generate a Monge matrix from a primitive.
+    pub fn to_matrix<T: PrimInt, R: Rng>(&self, m: usize, n: usize, rng: &mut R) -> Array2<T>
+    where
+        Standard: Distribution<T>,
+    {
+        let mut matrix = Array2::from_elem((m, n), T::zero());
+        // Avoid panic in UpperRightOnes and LowerLeftOnes below.
+        if m == 0 || n == 0 {
+            return matrix;
+        }
+
+        match *self {
+            MongePrim::ConstantRows => {
+                for mut row in matrix.genrows_mut() {
+                    if rng.gen::<bool>() {
+                        row.fill(T::one())
+                    }
+                }
+            }
+            MongePrim::ConstantCols => {
+                for mut col in matrix.gencolumns_mut() {
+                    if rng.gen::<bool>() {
+                        col.fill(T::one())
+                    }
+                }
+            }
+            MongePrim::UpperRightOnes => {
+                let i = rng.gen_range(0, (m + 1) as isize);
+                let j = rng.gen_range(0, (n + 1) as isize);
+                matrix.slice_mut(s![..i, -j..]).fill(T::one());
+            }
+            MongePrim::LowerLeftOnes => {
+                let i = rng.gen_range(0, (m + 1) as isize);
+                let j = rng.gen_range(0, (n + 1) as isize);
+                matrix.slice_mut(s![-i.., ..j]).fill(T::one());
+            }
+        }
+
+        matrix
+    }
+}
+
+/// Generate a random Monge matrix.
+pub fn random_monge_matrix<R: Rng, T: PrimInt>(m: usize, n: usize, rng: &mut R) -> Array2<T>
+where
+    Standard: Distribution<T>,
+{
+    let monge_primitives = [
+        MongePrim::ConstantRows,
+        MongePrim::ConstantCols,
+        MongePrim::LowerLeftOnes,
+        MongePrim::UpperRightOnes,
+    ];
+    let mut matrix = Array2::from_elem((m, n), T::zero());
+    for _ in 0..(m + n) {
+        let monge = monge_primitives[rng.gen_range(0, monge_primitives.len())];
+        matrix = matrix + monge.to_matrix(m, n, rng);
+    }
+    matrix
+}


### PR DESCRIPTION
The `random_monge_matrix` functionality has been moved to a test module — it's not the main focus of this crate, but it's still convenient for us to have this functionality for tests.