### PR TITLE
Only publish Rust files to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["smawk", "matrix", "optimization", "dynamic-programming"]
 categories = ["algorithms", "science"]
 license = "MIT"
 edition = "2018"
+exclude = [".github/", ".gitignore", "benches/", "examples/"]
 
 [badges]
 travis-ci = { repository = "mgeisler/smawk" }


### PR DESCRIPTION
The crate tarball still contain the tests just in case people want to run them from a downloaded crate.