### PR TITLE
Remove unused [badges] section from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,6 @@ license = "MIT"
 edition = "2018"
 exclude = [".github/", ".gitignore", "benches/", "examples/"]
 
-[badges]
-travis-ci = { repository = "mgeisler/smawk" }
-appveyor = { repository = "mgeisler/smawk" }
-codecov = { repository = "mgeisler/smawk" }
-
 [dependencies]
 ndarray = { version = "0.14", optional = true }
 


### PR DESCRIPTION
The badges are no longer shown on crates.io and I don’t think they were ever shown on lib.rs. According to the documentation we should instead rely on the badges in the README.

  https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section