### PR TITLE
Forbid the use of unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,9 @@
 //! matrix is a Monge matrix.
 
 #![doc(html_root_url = "https://docs.rs/smawk/0.3.1")]
+// The s! macro from ndarray uses unsafe internally, so we can only
+// forbid unsafe code when building with the default features.
+#![cfg_attr(not(feature = "ndarray"), forbid(unsafe_code))]
 
 #[cfg(feature = "ndarray")]
 pub mod brute_force;


### PR DESCRIPTION
This is to avoid us accidentally introducing unsafe code and to make the crate show up in green with `cargo geiger`, see

  https://github.com/rust-secure-code/cargo-geiger