### PR TITLE
Setup weekly builds to detect build failures on nightly Rust

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: build
 
-on: push
+on:
+  push:
+  schedule:
+    - cron: '30 10 * * 6'  # Every Saturday at 10:30 UTC
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This will trigger a build every Friday so that I can fix any issues ASAP over the weekend.