### PR TITLE
Use precise dependency versions in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2021"
 exclude = [".github/", ".gitignore", "benches/", "examples/"]
 
 [dependencies]
-ndarray = { version = "0.15", optional = true }
+ndarray = { version = "0.15.4", optional = true }
 
 [dev-dependencies]
-version-sync = "0.9"
-num-traits = "0.2"
-rand = "0.8"
-rand_chacha = "0.3"
+version-sync = "0.9.4"
+num-traits = "0.2.14"
+rand = "0.8.4"
+rand_chacha = "0.3.1"


### PR DESCRIPTION
Following the advice from [1], this PR updates Cargo.toml to use precise version numbers for all dependencies. The latest versions at the time of writing are used.

The tests passed both before and after this change, even when explicitly using the minimum versions of all dependencies.

[1]: https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277