### PR TITLE
Migrate to the Rust 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 keywords = ["smawk", "matrix", "optimization", "dynamic-programming"]
 categories = ["algorithms", "science"]
 license = "MIT"
-edition = "2018"
+edition = "2021"
 exclude = [".github/", ".gitignore", "benches/", "examples/"]
 
 [dependencies]


### PR DESCRIPTION
No changes necessary.