### PR TITLE
Remove cron setting from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: build
 
 on:
   push:
-  schedule:
-    - cron: "30 10 * * 6" # Every Saturday at 10:30 UTC
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
The repository does not have many commits, and this makes GitHub disable the workflow after 60 days. Removing the cron setting should help avoid this.