### PR TITLE
Remove `smawk_` prefix from optimized functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can now efficiently find row and column minima. Here is an example where we
 find the column minima:
 
 ```rust
-use smawk::smawk_column_minima;
+use smawk::Matrix;
 
 let matrix = vec![
     vec![3, 2, 4, 5, 6],
@@ -40,7 +40,7 @@ let matrix = vec![
     vec![4, 3, 2, 1, 1],
 ];
 let minima = vec![1, 1, 4, 4, 4];
-assert_eq!(smawk_column_minima(&matrix), minima);
+assert_eq!(smawk::column_minima(&matrix), minima);
 ```
 
 The `minima` vector gives the index of the minimum value per column, so

--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -65,6 +65,6 @@ repeat!(
         (row_smawk_200, column_smawk_200, 200),
         (row_smawk_400, column_smawk_400, 400)
     ],
-    smawk::smawk_row_minima,
-    smawk::smawk_column_minima
+    smawk::row_minima,
+    smawk::column_minima
 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,10 @@
 //! # Examples
 //!
 //! Computing the column minima of an *m* ✕ *n* Monge matrix can be
-//! done efficiently with `smawk_column_minima`:
+//! done efficiently with `smawk::column_minima`:
 //!
 //! ```
-//! use smawk::{Matrix, smawk_column_minima};
+//! use smawk::Matrix;
 //!
 //! let matrix = vec![
 //!     vec![3, 2, 4, 5, 6],
@@ -22,7 +22,7 @@
 //!     vec![4, 3, 2, 1, 1],
 //! ];
 //! let minima = vec![1, 1, 4, 4, 4];
-//! assert_eq!(smawk_column_minima(&matrix), minima);
+//! assert_eq!(smawk::column_minima(&matrix), minima);
 //! ```
 //!
 //! The `minima` vector gives the index of the minimum value per
@@ -168,11 +168,11 @@ impl<T: Copy> Matrix<T> for ndarray::Array2<T> {
 /// # Examples
 ///
 /// ```
-/// use smawk::{Matrix, smawk_row_minima};
+/// use smawk::Matrix;
 /// let matrix = vec![vec![4, 2, 4, 3],
 ///                   vec![5, 3, 5, 3],
 ///                   vec![5, 3, 3, 1]];
-/// assert_eq!(smawk_row_minima(&matrix),
+/// assert_eq!(smawk::row_minima(&matrix),
 ///            vec![1, 1, 3]);
 /// ```
 ///
@@ -182,7 +182,7 @@ impl<T: Copy> Matrix<T> for ndarray::Array2<T> {
 ///
 /// [pads]: https://github.com/jfinkels/PADS/blob/master/pads/smawk.py
 /// [SMAWK algorithm]: https://en.wikipedia.org/wiki/SMAWK_algorithm
-pub fn smawk_row_minima<T: PartialOrd + Copy, M: Matrix<T>>(matrix: &M) -> Vec<usize> {
+pub fn row_minima<T: PartialOrd + Copy, M: Matrix<T>>(matrix: &M) -> Vec<usize> {
     // Benchmarking shows that SMAWK performs roughly the same on row-
     // and column-major matrices.
     let mut minima = vec![0; matrix.nrows()];
@@ -210,11 +210,11 @@ pub fn smawk_row_minima<T: PartialOrd + Copy, M: Matrix<T>>(matrix: &M) -> Vec<u
 /// # Examples
 ///
 /// ```
-/// use smawk::{Matrix, smawk_column_minima};
+/// use smawk::Matrix;
 /// let matrix = vec![vec![4, 2, 4, 3],
 ///                   vec![5, 3, 5, 3],
 ///                   vec![5, 3, 3, 1]];
-/// assert_eq!(smawk_column_minima(&matrix),
+/// assert_eq!(smawk::column_minima(&matrix),
 ///            vec![0, 0, 2, 2]);
 /// ```
 ///
@@ -224,7 +224,7 @@ pub fn smawk_row_minima<T: PartialOrd + Copy, M: Matrix<T>>(matrix: &M) -> Vec<u
 ///
 /// [SMAWK algorithm]: https://en.wikipedia.org/wiki/SMAWK_algorithm
 /// [pads]: https://github.com/jfinkels/PADS/blob/master/pads/smawk.py
-pub fn smawk_column_minima<T: PartialOrd + Copy, M: Matrix<T>>(matrix: &M) -> Vec<usize> {
+pub fn column_minima<T: PartialOrd + Copy, M: Matrix<T>>(matrix: &M) -> Vec<usize> {
     let mut minima = vec![0; matrix.ncols()];
     smawk_inner(
         &|i, j| matrix.index(i, j),
@@ -415,8 +415,8 @@ mod tests {
     #[test]
     fn smawk_1x1() {
         let matrix = vec![vec![2]];
-        assert_eq!(smawk_row_minima(&matrix), vec![0]);
-        assert_eq!(smawk_column_minima(&matrix), vec![0]);
+        assert_eq!(row_minima(&matrix), vec![0]);
+        assert_eq!(column_minima(&matrix), vec![0]);
     }
 
     #[test]
@@ -425,15 +425,15 @@ mod tests {
             vec![3], //
             vec![2],
         ];
-        assert_eq!(smawk_row_minima(&matrix), vec![0, 0]);
-        assert_eq!(smawk_column_minima(&matrix), vec![1]);
+        assert_eq!(row_minima(&matrix), vec![0, 0]);
+        assert_eq!(column_minima(&matrix), vec![1]);
     }
 
     #[test]
     fn smawk_1x2() {
         let matrix = vec![vec![2, 1]];
-        assert_eq!(smawk_row_minima(&matrix), vec![1]);
-        assert_eq!(smawk_column_minima(&matrix), vec![0, 0]);
+        assert_eq!(row_minima(&matrix), vec![1]);
+        assert_eq!(column_minima(&matrix), vec![0, 0]);
     }
 
     #[test]
@@ -442,8 +442,8 @@ mod tests {
             vec![3, 2], //
             vec![2, 1],
         ];
-        assert_eq!(smawk_row_minima(&matrix), vec![1, 1]);
-        assert_eq!(smawk_column_minima(&matrix), vec![1, 1]);
+        assert_eq!(row_minima(&matrix), vec![1, 1]);
+        assert_eq!(column_minima(&matrix), vec![1, 1]);
     }
 
     #[test]
@@ -453,8 +453,8 @@ mod tests {
             vec![3, 4, 4],
             vec![2, 3, 3],
         ];
-        assert_eq!(smawk_row_minima(&matrix), vec![0, 0, 0]);
-        assert_eq!(smawk_column_minima(&matrix), vec![2, 2, 2]);
+        assert_eq!(row_minima(&matrix), vec![0, 0, 0]);
+        assert_eq!(column_minima(&matrix), vec![2, 2, 2]);
     }
 
     #[test]
@@ -465,8 +465,8 @@ mod tests {
             vec![2, 3, 3, 3],
             vec![2, 2, 2, 2],
         ];
-        assert_eq!(smawk_row_minima(&matrix), vec![0, 0, 0, 0]);
-        assert_eq!(smawk_column_minima(&matrix), vec![1, 3, 3, 3]);
+        assert_eq!(row_minima(&matrix), vec![0, 0, 0, 0]);
+        assert_eq!(column_minima(&matrix), vec![1, 3, 3, 3]);
     }
 
     #[test]
@@ -478,8 +478,8 @@ mod tests {
             vec![3, 2, 4, 3, 4],
             vec![4, 3, 2, 1, 1],
         ];
-        assert_eq!(smawk_row_minima(&matrix), vec![1, 1, 1, 1, 3]);
-        assert_eq!(smawk_column_minima(&matrix), vec![1, 1, 4, 4, 4]);
+        assert_eq!(row_minima(&matrix), vec![1, 1, 1, 1, 3]);
+        assert_eq!(column_minima(&matrix), vec![1, 1, 4, 4, 4]);
     }
 
     #[test]
@@ -541,8 +541,8 @@ mod tests {
             vec![3.0, 2.0], //
             vec![2.0, 1.0],
         ];
-        assert_eq!(smawk_row_minima(&matrix), vec![1, 1]);
-        assert_eq!(smawk_column_minima(&matrix), vec![1, 1]);
+        assert_eq!(row_minima(&matrix), vec![1, 1]);
+        assert_eq!(column_minima(&matrix), vec![1, 1]);
     }
 
     #[test]

--- a/tests/agreement.rs
+++ b/tests/agreement.rs
@@ -3,8 +3,8 @@
 use ndarray::{s, Array2};
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
+use smawk::online_column_minima;
 use smawk::{brute_force, recursive};
-use smawk::{online_column_minima, smawk_column_minima, smawk_row_minima};
 
 mod random_monge;
 use random_monge::random_monge_matrix;
@@ -24,7 +24,7 @@ fn column_minima_agree() {
                 // Compute and test row minima.
                 let brute_force = brute_force::row_minima(&matrix);
                 let recursive = recursive::row_minima(&matrix);
-                let smawk = smawk_row_minima(&matrix);
+                let smawk = smawk::row_minima(&matrix);
                 assert_eq!(
                     brute_force, recursive,
                     "recursive and brute force differs on:\n{:?}",
@@ -39,7 +39,7 @@ fn column_minima_agree() {
                 // Do the same for the column minima.
                 let brute_force = brute_force::column_minima(&matrix);
                 let recursive = recursive::column_minima(&matrix);
-                let smawk = smawk_column_minima(&matrix);
+                let smawk = smawk::column_minima(&matrix);
                 assert_eq!(
                     brute_force, recursive,
                     "recursive and brute force differs on:\n{:?}",


### PR DESCRIPTION
This makes it convenient to use the functions both with the crate name:

```rust
smawk::row_minima(&matrix);
```

and without:

```rust
use smawk::row_minima;
row_minima(&matrix);
```