### PR TITLE
Add GitHub Sponsors configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: mgeisler


### PR DESCRIPTION
I've been a passionate open-source contributor for over 25 years. I've enabled GitHub Sponsors to help support my work on my Rust projects.

If you find my work valuable, please consider supporting me. Your sponsorship will help cover hosting costs, development equipment, and travel to conferences to share my work with the community.