### PR TITLE
Add new `online` benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,8 @@ version-sync = "0.9.4"
 name = "comparison"
 harness = false
 required-features = ["ndarray"]
+
+[[bench]]
+name = "online"
+harness = false
+required-features = ["ndarray"]

--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -14,7 +14,7 @@ fn random_matrix(size: usize) -> Array2<i32> {
     random_monge_matrix(size, size, &mut rng)
 }
 
-const SIZES: [usize; 5] = [25, 50, 100, 200, 400];
+const SIZES: [usize; 5] = [50, 100, 200, 400, 800];
 
 // Brute Force
 

--- a/benches/online.rs
+++ b/benches/online.rs
@@ -1,0 +1,38 @@
+#![cfg(feature = "ndarray")]
+
+use divan::{AllocProfiler, Bencher};
+use ndarray::Array2;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
+
+#[path = "../tests/random_monge/mod.rs"]
+mod random_monge;
+use random_monge::random_monge_matrix;
+
+fn random_matrix(size: usize) -> Array2<i32> {
+    let mut rng = StdRng::seed_from_u64(0);
+    random_monge_matrix(size, size, &mut rng)
+}
+
+const SIZES: [usize; 5] = [50, 100, 200, 400, 800];
+
+#[divan::bench(name = "smawk_online_column_minima", consts = SIZES)]
+fn smawk_online_column_minima<const N: usize>(bencher: Bencher) {
+    let mut matrix = random_matrix(N);
+    let max = *matrix.iter().max().unwrap_or(&0);
+    for idx in 0..N {
+        matrix
+            .slice_mut(ndarray::s![idx..idx + 1, ..idx + 1])
+            .fill(max);
+    }
+    let initial = 42;
+    matrix.slice_mut(ndarray::s![0.., ..1]).fill(initial);
+    bencher.bench_local(|| smawk::online_column_minima(initial, N, |_, i, j| matrix[[i, j]]));
+}
+
+fn main() {
+    divan::main();
+}


### PR DESCRIPTION
This benchmarks the online SMAWK algorithm, which is the main feature of this crate and the one that is important for the Textwrap crate.

The benchmark sizes were increased a little to test a worst-case paragrpah with 800 words (or 500-600 words if automatic hyphenation is enabled, depending on the language).