### PR TITLE
Enable heap allocation benchmarking

### DIFF
--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -1,9 +1,12 @@
 #![cfg(feature = "ndarray")]
 
-use divan::Bencher;
+use divan::{AllocProfiler, Bencher};
 use ndarray::Array2;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
 
 #[path = "../tests/random_monge/mod.rs"]
 mod random_monge;


### PR DESCRIPTION
This shows that we do 21 heap allocations in `smawk_row_minima` and `smawk_column_minima` for the 400 × 400 matrix benchmark.