### PR TITLE
Revert "Bump actions/github-script from 3 to 9"

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Update changelog for version ${{ needs.setup.outputs.new-version }}
         id: changelog
-        uses: actions/github-script@v9
+        uses: actions/github-script@v3
         with:
           script: |
             var fs = require('fs')
@@ -139,7 +139,7 @@ jobs:
         run: git push origin
 
       - name: Create pull request
-        uses: actions/github-script@v9
+        uses: actions/github-script@v3
         with:
           script: |
             const pr = await github.pulls.create({

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Lookup ${{ steps.vars.outputs.version }} tag
         id: need-release
-        uses: actions/github-script@v9
+        uses: actions/github-script@v3
         with:
           script: |
             const version = '${{ steps.vars.outputs.version }}'


### PR DESCRIPTION
Reverts mgeisler/smawk#117 because of

```
Run actions/github-script@v9
TypeError: Cannot read properties of undefined (reading 'listReleases')
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v9/dist/index.js:64949:16), <anonymous>:8:37)
    at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v9/dist/index.js:64950:12)
    at main (/home/runner/work/_actions/actions/github-script/v9/dist/index.js:65100:26)
    at /home/runner/work/_actions/actions/github-script/v9/dist/index.js:65069:1
    at /home/runner/work/_actions/actions/github-script/v9/dist/index.js:65147:3
    at Object.<anonymous> (/home/runner/work/_actions/actions/github-script/v9/dist/index.js:65150:12)
    at Module._compile (node:internal/modules/cjs/loader:1854:14)
    at Object..js (node:internal/modules/cjs/loader:1985:10)
    at Module.load (node:internal/modules/cjs/loader:1577:32)
    at Module._load (node:internal/modules/cjs/loader:1379:12)
Error: Unhandled error: TypeError: Cannot read properties of undefined (reading 'listReleases')
```

I'll need to debug this some other time.