### PR TITLE
Specify `rustfmt` version and style edition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,13 +77,5 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      # We use an unstable rustfmt feature and we thus need the
-      # nightly channel to enforce the formatting.
-      - name: Setup Rust nightly
-        run: rustup default nightly
-
-      - name: Install rustfmt
-        run: rustup component add rustfmt
-
       - name: Check Formatting
         uses: dprint/check@v2.3

--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -2,8 +2,8 @@
 
 use divan::{AllocProfiler, Bencher};
 use ndarray::Array2;
-use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 
 #[global_allocator]
 static ALLOC: AllocProfiler = AllocProfiler::system();

--- a/benches/online.rs
+++ b/benches/online.rs
@@ -2,8 +2,8 @@
 
 use divan::{AllocProfiler, Bencher};
 use ndarray::Array2;
-use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 
 #[global_allocator]
 static ALLOC: AllocProfiler = AllocProfiler::system();

--- a/dprint.json
+++ b/dprint.json
@@ -4,7 +4,8 @@
   },
   "exec": {
     "commands": [{
-      "command": "rustfmt",
+      "setupCommand": "rustup toolchain install nightly-2026-06-25 --profile minimal --component rustfmt",
+      "command": "rustup run nightly-2026-06-25 rustfmt",
       "exts": ["rs"]
     }]
   },
@@ -13,7 +14,7 @@
     "https://plugins.dprint.dev/json-0.17.4.wasm",
     "https://plugins.dprint.dev/markdown-0.16.1.wasm",
     "https://plugins.dprint.dev/toml-0.5.4.wasm",
-    "https://plugins.dprint.dev/exec-0.4.3.json@42343548b8022c99b1d750be6b894fe6b6c7ee25f72ae9f9082226dd2e515072",
+    "https://plugins.dprint.dev/exec-0.7.2.json@6c30bd00dfb176774ece412d0fbf149478269ecc92c55ab2d6f4116938ed993e",
     "https://plugins.dprint.dev/prettier-0.27.0.json@3557a62b4507c55a47d8cde0683195b14d13c41dda66d0f0b0e111aed107e2fe"
   ]
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
+edition = "2024"
 # Use rustfmt from the nightly channel for this:
 imports_granularity = "Module"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,9 +461,7 @@ pub fn online_column_minima<T: Copy + PartialOrd, M: Fn(&[(usize, T)], usize, us
 
     // Shorthand for evaluating the matrix.
     macro_rules! m {
-        ($i:expr, $j:expr) => {{
-            matrix(&result[..finished + 1], $i, $j)
-        }};
+        ($i:expr, $j:expr) => {{ matrix(&result[..finished + 1], $i, $j) }};
     }
 
     let (mut rows_scratch, mut cols_scratch) = scratchpads_empty(size, size);

--- a/src/monge.rs
+++ b/src/monge.rs
@@ -34,11 +34,7 @@ where
         Wrapping<T>: Add<Output = Wrapping<T>>,
     {
         let sum = a + b;
-        if sum < a {
-            Err(sum.0)
-        } else {
-            Ok(sum.0)
-        }
+        if sum < a { Err(sum.0) } else { Ok(sum.0) }
     }
 
     (0..matrix.nrows() - 1)

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -8,7 +8,7 @@
 
 use alloc::vec;
 use alloc::vec::Vec;
-use ndarray::{s, Array2, ArrayView2, Axis};
+use ndarray::{Array2, ArrayView2, Axis, s};
 
 /// Compute row minima in O(*m* + *n* log *m*) time.
 ///

--- a/tests/agreement.rs
+++ b/tests/agreement.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "ndarray")]
 
-use ndarray::{s, Array2};
-use rand::rngs::StdRng;
+use ndarray::{Array2, s};
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 use smawk::{brute_force, online_column_minima, recursive};
 
 mod random_monge;

--- a/tests/complexity.rs
+++ b/tests/complexity.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "ndarray")]
 
 use ndarray::{Array1, Array2};
-use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 use smawk::online_column_minima;
 
 mod random_monge;

--- a/tests/monge.rs
+++ b/tests/monge.rs
@@ -1,13 +1,13 @@
 #![cfg(feature = "ndarray")]
 
-use ndarray::{arr2, Array, Array2};
+use ndarray::{Array, Array2, arr2};
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 use rstest::rstest;
 use smawk::monge::is_monge;
 
 mod random_monge;
-use random_monge::{random_monge_matrix, MongePrim};
+use random_monge::{MongePrim, random_monge_matrix};
 
 #[test]
 fn random_monge() {

--- a/tests/random_monge/mod.rs
+++ b/tests/random_monge/mod.rs
@@ -5,7 +5,7 @@
 // section on "Submodules in Integration Tests" in
 // https://doc.rust-lang.org/book/ch11-03-test-organization.html
 
-use ndarray::{s, Array2};
+use ndarray::{Array2, s};
 use num_traits::PrimInt;
 use rand::distr::{Distribution, StandardUniform};
 use rand::{Rng, RngExt};


### PR DESCRIPTION
With https://github.com/dprint/dprint/issues/1023 closed, we can now control the `rustfmt` version as part of the `dprint` configuration.

This updates the style edition to the latest versions.