### PR TITLE
Update references to the old `master` branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           # Avoid PRs filling up the cache.
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Quick smoke test to detect serious brokenness.
       - name: Build with default features
@@ -62,7 +62,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           # Avoid PRs filling up the cache.
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check no_std compatibility (default features)
         run: cargo check --target thumbv7m-none-eabi --no-default-features

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,9 +2,9 @@ name: coverage
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -20,7 +20,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           # Avoid PRs filling up the cache.
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -146,7 +146,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               head: 'release-${{ needs.setup.outputs.new-version }}',
-              base: 'master',
+              base: 'main',
               title: 'Release ${{ needs.setup.outputs.new-version }}',
               body: process.env.CHANGELOG,
             })

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -3,7 +3,7 @@ name: Publish Crate
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - Cargo.toml
   repository_dispatch:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SMAWK Algorithm in Rust
 
 [![](https://github.com/mgeisler/smawk/workflows/build/badge.svg)][build-status]
-[![](https://codecov.io/gh/mgeisler/smawk/branch/master/graph/badge.svg)][codecov]
+[![](https://codecov.io/gh/mgeisler/smawk/branch/main/graph/badge.svg)][codecov]
 [![](https://img.shields.io/crates/v/smawk.svg)][crates-io]
 [![](https://docs.rs/smawk/badge.svg)][api-docs]
 
@@ -163,7 +163,7 @@ minima.
 SMAWK can be distributed according to the [MIT license][mit]. Contributions will
 be accepted under the same license.
 
-[build-status]: https://github.com/mgeisler/smawk/actions?query=branch%3Amaster+workflow%3Abuild
+[build-status]: https://github.com/mgeisler/smawk/actions?query=branch%3Amain+workflow%3Abuild
 [crates-io]: https://crates.io/crates/smawk
 [codecov]: https://codecov.io/gh/mgeisler/smawk
 [textwrap]: https://crates.io/crates/textwrap


### PR DESCRIPTION
The branch has been renamed to `main`, but there were many left-over references in the code and in build scripts.